### PR TITLE
setup recorder

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -145,8 +145,9 @@ func main() {
 	}
 
 	if err = (&controller.MemcachedReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("memcached-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Memcached")
 		os.Exit(1)


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `MemcachedReconciler` setup in `cmd/main.go`. The change adds an event recorder to the reconciler, enabling it to log events for better observability and debugging.

* [`cmd/main.go`](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6R150): Added the `Recorder` field to the `MemcachedReconciler` initialization, using `mgr.GetEventRecorderFor("memcached-controller")` to enable event recording.