### PR TITLE
set max concurrent reconciles

### DIFF
--- a/internal/controller/memcached_controller.go
+++ b/internal/controller/memcached_controller.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -384,5 +385,6 @@ func (r *MemcachedReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&cachev1alpha1.Memcached{}).
 		Owns(&appsv1.Deployment{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 2}).
 		Complete(r)
 }


### PR DESCRIPTION
This pull request introduces a minor update to the `MemcachedReconciler` in the `internal/controller/memcached_controller.go` file, enhancing the controller's configuration and functionality.

### Controller configuration enhancements:

* Added the `controller` package to the import list to enable controller-specific options. (`[internal/controller/memcached_controller.goR36](diffhunk://#diff-2c2caea9537bcff881f42cb8fc939e5ca61d0225c595788c89a133fb49b9d797R36)`)
* Configured the `MemcachedReconciler` to use `WithOptions` with a `MaxConcurrentReconciles` value of 2, improving concurrency for reconcile operations. (`[internal/controller/memcached_controller.goR388](diffhunk://#diff-2c2caea9537bcff881f42cb8fc939e5ca61d0225c595788c89a133fb49b9d797R388)`)